### PR TITLE
fix: MCQ correct/wrong highlight now visible over btn-outline

### DIFF
--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -407,18 +407,28 @@
   margin-top: 10px;
 }
 
-.sprout-mcq-correct-highlight {
+/* Use .sprout .btn-outline.<class> to beat .sprout .btn-outline specificity (0-3-0 > 0-2-0) */
+.sprout .btn-outline.sprout-mcq-correct-highlight {
   border-color: rgb(34, 197, 94) !important;
   background-color: rgb(220, 252, 231) !important;
-  border-width: 2px;
-  border-style: solid;
+  border-width: 2px !important;
+  border-style: solid !important;
 }
 
-.sprout-mcq-wrong-highlight {
+.sprout .btn-outline.sprout-mcq-wrong-highlight {
   border-color: rgb(239, 68, 68) !important;
   background-color: rgb(254, 226, 226) !important;
-  border-width: 2px;
-  border-style: solid;
+  border-width: 2px !important;
+  border-style: solid !important;
+}
+
+/* Dark mode: softer MCQ highlight backgrounds */
+.theme-dark .sprout .btn-outline.sprout-mcq-correct-highlight {
+  background-color: rgba(34, 197, 94, 0.15) !important;
+}
+
+.theme-dark .sprout .btn-outline.sprout-mcq-wrong-highlight {
+  background-color: rgba(239, 68, 68, 0.15) !important;
 }
 
 .sprout-mcq-option-text {


### PR DESCRIPTION
## Problem
MCQ answer buttons in the main reviewer didn't show green (correct) or red (wrong) borders after answering, even though the highlight classes were being added to the DOM.

## Root cause
PostCSS `prefix-selector` skips selectors containing `.sprout`. So `.sprout-mcq-correct-highlight` stayed at specificity **0-1-0**, while `.btn-outline` became `.sprout .btn-outline` at **0-2-0** — always winning.

## Fix
Changed highlight selectors to `.sprout .btn-outline.sprout-mcq-correct-highlight` (specificity **0-3-0**), which reliably overrides btn-outline borders and backgrounds.

Also added dark-mode variants with the same specificity.