### PR TITLE
docs(changelog): update latest pre-release notes for 1.0.5-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,24 @@
 All notable changes to Sprout are summarized here.
 
 <details open>
-<summary><strong>Latest release: 1.0.5 (2026-02-13)</strong></summary>
+<summary><strong>Latest pre-release: 1.0.5-beta.1 (2026-02-16)</strong></summary>
 
-### Latest release notes
+### Pre-release notes
+
+Targeting final `1.0.5`.
 
 #### Changed
-- Added plugin scaling support
-- Enabled text selection for copying card content
-- Added multi-select questions (MCQ subtype)
-- Added reversed and ordered questions
-- Added the wiki directly in the app
-- Added a new settings view
+- Added new card types: multi-select MCQ and ordered questions for memorising sequences
+- Added more card customisation: typed cloze and customisation of image occlusion masks
+- Overhauled Reading view with two styles: Flashcards and Clean markdown
+- Added a new settings view with more control
+- Updated the guide and made it visible directly within Obsidian
 
 #### Fixed
-- Analytics chart compatibility and type definitions
-- Tag box styling consistency across browser, modals, and card editor
+- Limited modal background/overlay to the workspace so tab-switching remains available
+
+#### Planned
+- Additional Reading styles and full Custom Reading style support are planned for a future update
 
 #### Hint
 If scheduling or analytics data is lost after an update, restore from a backup.


### PR DESCRIPTION
## Summary\n- update CHANGELOG latest entry to 1.0.5-beta.1 pre-release\n- align changed/fixed/planned bullets with current pre-release notes\n- keep restore-from-backup hint in latest section\n\n## Context\nRelease/code updates were already pushed directly to main; this PR captures the remaining changelog update for review.