### PR TITLE
ci: run wiki badge update after wiki sync

### DIFF
--- a/.github/workflows/wiki-page-count-badge.yml
+++ b/.github/workflows/wiki-page-count-badge.yml
@@ -1,10 +1,12 @@
 name: Update Wiki Badge Count
 
 on:
+  workflow_run:
+    workflows: ["Sync GitHub Wiki"]
+    types: [completed]
   push:
     branches: [main]
     paths:
-      - "wiki/**/*.md"
       - ".github/workflows/wiki-page-count-badge.yml"
   workflow_dispatch:
 
@@ -14,6 +16,7 @@ permissions:
 
 jobs:
   update-wiki-badge:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Runs wiki badge counting after the Sync GitHub Wiki workflow completes successfully, then auto-opens and auto-merges the badge PR when checks pass.