### PR TITLE
fix(mobile): restore iOS study session scroll in Practice

### DIFF
--- a/src/platform/core/mobile-session-scroll.ts
+++ b/src/platform/core/mobile-session-scroll.ts
@@ -1,0 +1,76 @@
+/**
+ * @file mobile-session-scroll.ts
+ * @summary Keeps flashcard study-session scrolling inside the card section on iOS
+ * so Obsidian Mobile Quick Action (pull-down → command palette) does not fire first.
+ */
+
+import { Platform } from "obsidian";
+
+function isPhoneLikeMobile(): boolean {
+  if (!Platform.isMobileApp) return false;
+  if (activeDocument.body.classList.contains("is-phone")) return true;
+  return (
+    activeDocument.body.classList.contains("is-mobile") &&
+    window.matchMedia("(max-width: 767px)").matches
+  );
+}
+
+function resolveSessionScrollContainer(target: EventTarget | null, root: ParentNode): HTMLElement | null {
+  if (!(target instanceof Element)) return null;
+  const section = target.closest<HTMLElement>(".lk-session-card > section");
+  if (section && root.contains(section)) return section;
+  return null;
+}
+
+/**
+ * Stop touchmove from bubbling to Obsidian when the session section can scroll.
+ * Uses delegation on the review root so card re-renders do not drop listeners.
+ * Returns a cleanup function.
+ */
+export function installMobileSessionScroll(root: ParentNode): () => void {
+  if (!isPhoneLikeMobile()) return () => {};
+
+  const host = root instanceof HTMLElement ? root : null;
+  if (!host) return () => {};
+
+  const touchState = new WeakMap<HTMLElement, number>();
+
+  const onTouchStart = (event: TouchEvent) => {
+    if (event.touches.length !== 1) return;
+    const scrollContainer = resolveSessionScrollContainer(event.target, host);
+    if (!scrollContainer) return;
+    touchState.set(scrollContainer, event.touches[0].clientY);
+  };
+
+  const onTouchMove = (event: TouchEvent) => {
+    if (event.touches.length !== 1) return;
+
+    const scrollContainer = resolveSessionScrollContainer(event.target, host);
+    if (!scrollContainer) return;
+
+    const touchY = event.touches[0].clientY;
+    const lastTouchY = touchState.get(scrollContainer) ?? touchY;
+    const deltaY = touchY - lastTouchY;
+    touchState.set(scrollContainer, touchY);
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+    if (scrollHeight <= clientHeight + 1) return;
+
+    const atTop = scrollTop <= 0;
+    const atBottom = scrollTop + clientHeight >= scrollHeight - 1;
+    const pullingPastEdge = (deltaY > 0 && atTop) || (deltaY < 0 && atBottom);
+
+    // Trap scroll inside the shell (including at edges) to avoid iOS bounce / parent chaining.
+    event.stopPropagation();
+
+    if (pullingPastEdge) event.preventDefault();
+  };
+
+  host.addEventListener("touchstart", onTouchStart, { passive: true, capture: true });
+  host.addEventListener("touchmove", onTouchMove, { passive: false, capture: true });
+
+  return () => {
+    host.removeEventListener("touchstart", onTouchStart, true);
+    host.removeEventListener("touchmove", onTouchMove, true);
+  };
+}

--- a/src/platform/styles/header.css
+++ b/src/platform/styles/header.css
@@ -6,6 +6,12 @@
   --learnkit-app-header-inset: 10px;
   --learnkit-app-header-top: 8px;
   --learnkit-app-header-overlay-height: 64px;
+  --learnkit-app-header-clearance: calc(
+    env(safe-area-inset-top, 0px) +
+    var(--learnkit-app-header-top) +
+    var(--learnkit-app-header-overlay-height) +
+    20px
+  );
   background: transparent;
   background-color: transparent;
   position: absolute;

--- a/src/platform/styles/session.css
+++ b/src/platform/styles/session.css
@@ -1869,68 +1869,116 @@ body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] > .lk-rev
   z-index: 10;
 }
 
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] {
+/* iOS: flex card with section scroll; lock ancestors to avoid Obsidian Quick Action. */
+body.is-phone .workspace-leaf-content.learnkit[data-type="learnkit-reviewer"],
+body.is-mobile .workspace-leaf-content.learnkit[data-type="learnkit-reviewer"] {
+  overflow: hidden;
+  min-height: 0;
+  overscroll-behavior: none;
+}
+
+body.is-phone .workspace-leaf-content.learnkit[data-type="learnkit-reviewer"] > .view-content,
+body.is-mobile .workspace-leaf-content.learnkit[data-type="learnkit-reviewer"] > .view-content {
+  flex: 1 1 0%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+/* App header clearance: session mode must not zero layout.css mobile padding-top (60px). */
+body.is-phone .learnkit .learnkit-view-content.lk-review-root[data-lk-review-mode="session"],
+body.is-mobile .learnkit .learnkit-view-content.lk-review-root[data-lk-review-mode="session"] {
+  overflow-x: hidden;
+  overflow-y: hidden;
+  min-height: 0;
+  flex: 1 1 0%;
+  display: flex;
+  flex-direction: column;
+  padding-top: max(72px, var(--learnkit-app-header-clearance, 94px));
+  box-sizing: border-box;
+  overscroll-behavior: none;
+}
+
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"],
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] {
   display: flex;
   flex-direction: column;
   overflow: hidden ;
-  margin-top: 16px;
+  margin-top: 0;
   padding-left: 0 ;
   padding-right: 0 ;
   padding-bottom: 100px ;
+  overscroll-behavior: none;
 }
 
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] > .lk-review-content-shell {
-  flex: 1 1 auto;
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] > .lk-review-content-shell,
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] > .lk-review-content-shell {
+  flex: 1 1 0%;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  overflow: visible ;
-  margin-top: 40px;
+  overflow: hidden;
+  margin-top: 12px;
   padding: 0 ;
+  overscroll-behavior: none;
 }
 
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-column {
-  flex: 1 1 auto;
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-column,
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-column {
+  flex: 1 1 0%;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] :is(.lk-session-card, .lk-session-card.card) {
-  --learnkit-session-topbar-clearance: 60px;
-  --learnkit-session-dock-clearance: 120px;
-  position: relative;
-  flex: 1 1 auto;
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] :is(.lk-session-card, .lk-session-card.card),
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] :is(.lk-session-card, .lk-session-card.card) {
+  --learnkit-session-topbar-offset: 10px;
+  flex: 1 1 0%;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
-  height: auto;
   max-height: none;
   align-self: stretch;
-  overflow: hidden ;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   padding: 0 ;
+  transition: none;
 }
 
-/* Note-review-style overlay layout: header & footer float absolute over
-   the section, which scrolls behind them with padding clearance. */
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > header {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > header.learnkit-session-topbar:not(.learnkit-session-topbar-hidden),
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > header.learnkit-session-topbar:not(.learnkit-session-topbar-hidden) {
+  flex: 0 0 auto;
+  position: static;
   z-index: 5;
-  background: color-mix(in oklab, var(--background) 80%, transparent 20%);
+  margin: var(--learnkit-session-topbar-offset) 0 0;
+  background: color-mix(in oklab, var(--background) 88%, transparent 12%);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
 
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > section {
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > section,
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > section {
   flex: 1 1 auto;
   min-height: 0;
+  margin: 0 8px;
+  overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding-top: var(--learnkit-session-topbar-clearance);
-  padding-bottom: var(--learnkit-session-dock-clearance);
+  touch-action: pan-y;
+  overscroll-behavior: none;
+  padding: 8px 0;
+}
+
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card.learnkit-session-has-dock > section,
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card.learnkit-session-has-dock > section {
+  padding-bottom: 8px;
+}
+
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > header.learnkit-session-topbar-hidden + section,
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > header.learnkit-session-topbar-hidden + section {
+  padding-top: 8px;
 }
 
 /* Keep scrolling at the section level on phone; avoid nested vertical scrollboxes in content blocks.
@@ -1946,12 +1994,12 @@ body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-sessi
   overflow: visible ;
 }
 
-body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > footer.learnkit-session-study-dock {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+body.is-phone .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > footer.learnkit-session-study-dock,
+body.is-mobile .learnkit .lk-review-root[data-lk-review-mode="session"] .lk-session-card > footer.learnkit-session-study-dock {
+  flex: 0 0 auto;
+  position: static;
   z-index: 5;
+  margin: 0 8px 8px;
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }

--- a/src/views/reviewer/render-session.ts
+++ b/src/views/reviewer/render-session.ts
@@ -1053,33 +1053,55 @@ function renderOqContent(ctx: CardRenderCtx): void {
           previewController.endDrag();
         });
 
-        // Touch drag support for mobile
+        // Touch drag support for mobile — defer preventDefault until reorder drag commits
+        // so vertical swipes can still scroll the session card on iOS.
+        let touchStartY = 0;
+        let touchStartX = 0;
+        let touchReorderActive = false;
+        const touchDragThresholdPx = 10;
+
         row.addEventListener("touchstart", (e) => {
           const touch = e.touches[0];
           if (!touch) return;
-          previewController.beginDrag({
-            fromIdx: displayIdx,
-            row,
-          });
-          previewController.updatePointer(touch.clientY);
+          touchStartY = touch.clientY;
+          touchStartX = touch.clientX;
+          touchReorderActive = false;
         }, { passive: true });
 
         row.addEventListener("touchmove", (e) => {
           const touch = e.touches[0];
           if (!touch) return;
+
+          const deltaY = touch.clientY - touchStartY;
+          const deltaX = touch.clientX - touchStartX;
+          if (!touchReorderActive) {
+            if (Math.abs(deltaY) < touchDragThresholdPx && Math.abs(deltaX) < touchDragThresholdPx) {
+              return;
+            }
+            touchReorderActive = true;
+            previewController.beginDrag({
+              fromIdx: displayIdx,
+              row,
+            });
+          }
+
           e.preventDefault();
           previewController.updatePointer(touch.clientY);
         }, { passive: false });
 
         row.addEventListener("touchend", () => {
+          if (!touchReorderActive) return;
           const pending = previewController.getPendingMove();
           previewController.endDrag();
+          touchReorderActive = false;
           if (!pending) return;
           commitReorder(pending.fromIdx, pending.toIdx);
         });
 
         row.addEventListener("touchcancel", () => {
+          if (!touchReorderActive) return;
           previewController.endDrag();
+          touchReorderActive = false;
         });
 
         listWrap.appendChild(row);

--- a/src/views/reviewer/review-view.ts
+++ b/src/views/reviewer/review-view.ts
@@ -11,6 +11,7 @@ import { ItemView, Notice, type WorkspaceLeaf, TFile, setIcon } from "obsidian";
 import { MAX_CONTENT_WIDTH, MAX_CONTENT_WIDTH_PX, VIEW_TYPE_REVIEWER } from "../../platform/core/constants";
 import { log } from "../../platform/core/logger";
 import { queryFirst, setCssProps } from "../../platform/core/ui";
+import { installMobileSessionScroll } from "../../platform/core/mobile-session-scroll";
 import { createTitleStripFrame } from "../../platform/core/view-primitives";
 import { SPROUT_HOME_CONTENT_SHELL_CLASS } from "../../platform/core/ui-classes";
 import { gradeCard } from "../../platform/services/grading-service";
@@ -160,6 +161,13 @@ export class SproutReviewerView extends ItemView {
     else this.containerEl.focus({ preventScroll: true });
   }
 
+  private _syncMobileSessionScroll(): void {
+    this._mobileSessionScrollCleanup?.();
+    this._mobileSessionScrollCleanup = null;
+    if (this.mode !== "session") return;
+    this._mobileSessionScrollCleanup = installMobileSessionScroll(this.contentEl);
+  }
+
   // Add shared header instance
   private _header: SproutHeader | null = null;
   private _titleStripEl: HTMLElement | null = null;
@@ -172,6 +180,7 @@ export class SproutReviewerView extends ItemView {
   private _pendingManualGrade: { cardId: string; meta: Record<string, unknown> } | null = null;
   private _pendingHotspotAttempts = new Map<string, HotspotAttemptState[]>();
   private _lastAppliedHotspotStudyMode: "individual" | "all" | "smart" = "smart";
+  private _mobileSessionScrollCleanup: (() => void) | null = null;
 
   // Typed cloze state: stores what the user typed for each cloze occurrence on the current card
   private _typedClozeAnswers = new Map<string, string>();
@@ -2698,6 +2707,10 @@ export class SproutReviewerView extends ItemView {
 
   render() {
     const root = this.contentEl;
+    if (this.mode !== "session") {
+      this._mobileSessionScrollCleanup?.();
+      this._mobileSessionScrollCleanup = null;
+    }
     const suppressEntranceAos = this._suppressEntranceAosOnce;
     this._suppressEntranceAosOnce = false;
     const coachShellMode = this._returnToCoach || this._isCoachSession;
@@ -2865,6 +2878,7 @@ export class SproutReviewerView extends ItemView {
         // TTS: speak front after render
         if (activeCard && !this.showAnswer) this._speakCardFront(activeCard);
 
+        this._syncMobileSessionScroll();
         this._restoreFocus();
         return;
       }
@@ -3196,6 +3210,8 @@ export class SproutReviewerView extends ItemView {
       this._firstSessionRender = false;
       this.armTimer();
     }
+
+    this._syncMobileSessionScroll();
 
     this._restoreFocus();
   }


### PR DESCRIPTION
## Summary

- Fix vertical scrolling in mobile study sessions (Practice) on iOS Obsidian where the first swipe opened Quick Action instead of scrolling card content
- Preserve clearance below the floating LearnKit app header and keep the card title bar / study dock (Next, Edit, More) visually stable while scrolling
- Add `mobile-session-scroll.ts` to trap touch events inside the scrollable section and reduce rubber-band / scroll chaining
- Defer ordered-question drag `preventDefault` until a 10px movement threshold so vertical swipes can still scroll

## Test plan

- [x] iPhone / Obsidian Mobile — open Practice session with a long MCQ card
- [x] Vertical scroll works inside the card body (Question, answers, extra info)
- [x] Card title bar clears the app header; study dock stays pinned at the bottom without jitter when scrolling up
- [x] Reduced bounce / accidental command palette on edge swipes
- [ ] iPad / `is-mobile` tablet layout smoke check
- [ ] Ordered-question reorder still works after threshold drag


Made with [Cursor](https://cursor.com)